### PR TITLE
Corrigindo Bugs e falha de segurança

### DIFF
--- a/app/Livewire/GrupoForm.php
+++ b/app/Livewire/GrupoForm.php
@@ -42,7 +42,7 @@ class GrupoForm extends Component
     #[On('criarGrupo')]
     public function criarGrupo()
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         $this->mount();
         $this->dispatch('openGrupoModal', modalTitle: 'Novo grupo');
     }
@@ -50,7 +50,7 @@ class GrupoForm extends Component
     #[On('editarGrupo')]
     public function editarGrupo($grupoId)
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         $this->grupo = Grupo::find($grupoId);
         $this->colunaArray = $this->grupo->colunaArray();
         $this->ordemArray = $this->grupo->ordemArray();
@@ -59,7 +59,7 @@ class GrupoForm extends Component
     }
 
     public function salvarGrupo() {
-        Gate::allows('manager');
+        Gate::authorize('manager');
 
         $this->validate();
         $this->grupo->save();
@@ -71,7 +71,7 @@ class GrupoForm extends Component
 
     #[On('destruirGrupo')]
     public function destruirGrupo($grupoId) {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         Grupo::destroy($grupoId);
         $this->mount();
         $this->dispatch('refresh')->to(ShowGrupos::class);

--- a/app/Livewire/GrupoForm.php
+++ b/app/Livewire/GrupoForm.php
@@ -6,6 +6,7 @@ use App\Models\Grupo;
 use Livewire\Component;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
+use Livewire\Attributes\Locked;
 
 class GrupoForm extends Component
 {
@@ -13,6 +14,9 @@ class GrupoForm extends Component
     public $grupo;
     public $colunaArray;
     public $ordemArray;
+
+    #[Locked]
+    public bool $isManager = false;
 
     public function rules()
     {
@@ -42,46 +46,53 @@ class GrupoForm extends Component
     #[On('criarGrupo')]
     public function criarGrupo()
     {
-        Gate::authorize('manager');
-        $this->mount();
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
+        $this->limparFormulario();
         $this->dispatch('openGrupoModal', modalTitle: 'Novo grupo');
     }
 
     #[On('editarGrupo')]
     public function editarGrupo($grupoId)
     {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
         $this->grupo = Grupo::find($grupoId);
         $this->colunaArray = $this->grupo->colunaArray();
         $this->ordemArray = $this->grupo->ordemArray();
         $this->dispatch('openGrupoModal', modalTitle: 'Editar grupo');
-        $this->validate();
+        $this->resetValidation();
     }
 
     public function salvarGrupo() {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
 
         $this->validate();
         $this->grupo->save();
 
         $this->dispatch('closeGrupoModal');
-        $this->mount();
+        $this->limparFormulario();
         $this->dispatch('refresh')->to(ShowGrupos::class);
     }
 
     #[On('destruirGrupo')]
     public function destruirGrupo($grupoId) {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
         Grupo::destroy($grupoId);
-        $this->mount();
+        $this->limparFormulario();
         $this->dispatch('refresh')->to(ShowGrupos::class);
     }
 
     public function mount()
     {
+        $this->isManager = Gate::check('manager');
+        $this->limparFormulario();
+    }
+
+    public function limparFormulario()
+    {
         $this->grupo = new Grupo;
-        $this->colunaArray = array_merge(['0'=>'?'],$this->grupo->colunaArray());
-        $this->ordemArray = []; // será carregado dinamicamente
+        $this->colunaArray = array_merge(['0'=>'?'], $this->grupo->colunaArray());
+        $this->ordemArray = []; 
+        $this->resetValidation();
     }
 
     public function render()

--- a/app/Livewire/GrupoForm.php
+++ b/app/Livewire/GrupoForm.php
@@ -19,10 +19,13 @@ class GrupoForm extends Component
     public bool $isManager = false;
 
     public function rules()
-    {
+    {   
+
+        $colunasValidas = implode(',', array_keys($this->colunaArray));
+
         return [
             'grupo.nome' => 'required|string|max:100',
-            'grupo.coluna' => 'required|integer|min:1', //colocar limites min e max
+            'grupo.coluna' => "required|integer|min:1|in:{$colunasValidas}",
             'grupo.linha' => 'required|integer',
             'grupo.exibir' => 'required|boolean',
             'grupo.descricao' => 'nullable|string',
@@ -56,7 +59,7 @@ class GrupoForm extends Component
     {
         abort_if(!$this->isManager, 403, 'Acesso Negado');
         $this->grupo = Grupo::find($grupoId);
-        $this->colunaArray = $this->grupo->colunaArray();
+        $this->colunaArray = Grupo::colunaArray($this->grupo->coluna);
         $this->ordemArray = $this->grupo->ordemArray();
         $this->dispatch('openGrupoModal', modalTitle: 'Editar grupo');
         $this->resetValidation();
@@ -90,7 +93,7 @@ class GrupoForm extends Component
     public function limparFormulario()
     {
         $this->grupo = new Grupo;
-        $this->colunaArray = array_merge(['0'=>'?'], $this->grupo->colunaArray());
+        $this->colunaArray = Grupo::colunaArray();
         $this->ordemArray = []; 
         $this->resetValidation();
     }

--- a/app/Livewire/ItemForm.php
+++ b/app/Livewire/ItemForm.php
@@ -30,7 +30,7 @@ class ItemForm extends Component
     #[On('criarItem')]
     public function criarItem($grupo_id = null)
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         $this->mount();
         $this->item->grupo_id = $grupo_id;
         $this->dispatch('openItemModal', modalTitle:'Novo item');
@@ -39,7 +39,7 @@ class ItemForm extends Component
     #[On('editarItem')]
     public function editarItem($itemId)
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         $this->item = Item::find($itemId);
         $this->gruposSelect = Grupo::pluck('nome', 'id');
         $this->dispatch('openItemModal', modalTitle: 'Editar item');
@@ -48,7 +48,7 @@ class ItemForm extends Component
 
     public function salvarItem()
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         $this->validate();
         $this->item->save();
         $this->dispatch('closeItemModal');
@@ -59,7 +59,7 @@ class ItemForm extends Component
     #[On('destruirItem')]
     public function destruirItem($itemId)
     {
-        Gate::allows('manager');
+        Gate::authorize('manager');
         Item::destroy($itemId);
         $this->mount(); // inicializa as variaveis
         $this->dispatch('refresh')->to(ShowGrupos::class);

--- a/app/Livewire/ItemForm.php
+++ b/app/Livewire/ItemForm.php
@@ -7,12 +7,16 @@ use App\Models\Item;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
 use Livewire\Component;
+use Livewire\Attributes\Locked;
 
 class ItemForm extends Component
 {
 
     public $item;
     public $gruposSelect;
+
+    #[Locked]
+    public bool $isManager = false;
 
     protected $rules = [
         'item.nome' => 'required',
@@ -30,8 +34,8 @@ class ItemForm extends Component
     #[On('criarItem')]
     public function criarItem($grupo_id = null)
     {
-        Gate::authorize('manager');
-        $this->mount();
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
+        $this->limparFormulario();
         $this->item->grupo_id = $grupo_id;
         $this->dispatch('openItemModal', modalTitle:'Novo item');
     }
@@ -39,7 +43,7 @@ class ItemForm extends Component
     #[On('editarItem')]
     public function editarItem($itemId)
     {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
         $this->item = Item::find($itemId);
         $this->gruposSelect = Grupo::pluck('nome', 'id');
         $this->dispatch('openItemModal', modalTitle: 'Editar item');
@@ -48,24 +52,30 @@ class ItemForm extends Component
 
     public function salvarItem()
     {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
         $this->validate();
         $this->item->save();
         $this->dispatch('closeItemModal');
-        $this->mount();
+        $this->limparFormulario();
         $this->dispatch('refresh')->to(ShowGrupos::class);
     }
 
     #[On('destruirItem')]
     public function destruirItem($itemId)
     {
-        Gate::authorize('manager');
+        abort_if(!$this->isManager, 403, 'Acesso Negado');
         Item::destroy($itemId);
-        $this->mount(); // inicializa as variaveis
+        $this->limparFormulario();
         $this->dispatch('refresh')->to(ShowGrupos::class);
     }
 
     public function mount()
+    {   
+        $this->isManager = Gate::check('manager');
+        $this->limparFormulario();
+    }
+
+    public function limparFormulario()
     {
         $this->item = new Item;
         $this->gruposSelect = Grupo::pluck('nome', 'id')->prepend('Selecione um..', 0);
@@ -77,4 +87,6 @@ class ItemForm extends Component
     {
         return view('livewire.item-form');
     }
+
+    
 }

--- a/app/Livewire/ShowGrupos.php
+++ b/app/Livewire/ShowGrupos.php
@@ -8,6 +8,7 @@ use Livewire\Component;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
 use Livewire\Attributes\On;
+use Livewire\Attributes\Locked;
 
 class ShowGrupos extends Component
 {
@@ -17,6 +18,9 @@ class ShowGrupos extends Component
     public $colunasPerdidas;
     public $gerenciar;
 
+    #[Locked]
+    public bool $isManager = false;
+
     public function updateItensOrder($order)
     {
    //    dd($order);
@@ -25,19 +29,19 @@ class ShowGrupos extends Component
     #[On('refresh')]
     public function refresh()
     {
-        $this->itensSemGrupo = Gate::allows('manager') ? Item::whereNull('grupo_id')->get() : collect();
+        $this->itensSemGrupo = $this->isManager ? Item::whereNull('grupo_id')->get() : collect();
         $this->grupos = Grupo::all();
     }
 
     public function menuDinamico()
     {
-        if (Gate::allows('manager') && $this->gerenciar == 0) {
+        if ($this->isManager && $this->gerenciar == 0) {
             \UspTheme::addMenu('portal-sistemas', [
                 'text' => '<button class="btn btn-danger btn-sm">Habilitar edição</button>',
                 'url' => '?gerenciar=1',
             ]);
         }
-        if (Gate::allows('manager') && $this->gerenciar == 1) {
+        if ($this->isManager && $this->gerenciar == 1) {
             \UspTheme::addMenu('portal-sistemas', [
                 [
                     'text' => '<button class="btn btn-success btn-sm">Finalizar edição</button>',
@@ -64,11 +68,14 @@ class ShowGrupos extends Component
     }
 
     public function mount(Request $request = null)
-    {
+    {   
+
+        $this->isManager = Gate::check('manager');
+
         $this->gerenciar($request);
         $this->menuDinamico();
 
-        $this->itensSemGrupo = Gate::allows('manager') ? Item::whereNull('grupo_id')->get() : collect();
+        $this->itensSemGrupo = $this->isManager ? Item::whereNull('grupo_id')->get() : collect();
         $this->grupos = Grupo::all();
 
         $this->colunas = range(1, config('portal-sistemas.num_cols'));

--- a/app/Livewire/ShowGrupos.php
+++ b/app/Livewire/ShowGrupos.php
@@ -25,7 +25,8 @@ class ShowGrupos extends Component
     #[On('refresh')]
     public function refresh()
     {
-        $this->mount();
+        $this->itensSemGrupo = Gate::allows('manager') ? Item::whereNull('grupo_id')->get() : collect();
+        $this->grupos = Grupo::all();
     }
 
     public function menuDinamico()

--- a/app/Models/Grupo.php
+++ b/app/Models/Grupo.php
@@ -147,11 +147,20 @@ class Grupo extends Model
         return $this;
     }
 
-    public static function colunaArray()
-    {
-        $range = range(1, config('portal-sistemas.num_cols'));
-        return array_combine($range, $range);
+public static function colunaArray($colunaAtual = null)
+{
+    $num_cols = config('portal-sistemas.num_cols');
+    $range = range(1, $num_cols);
+    $opcoes = array_combine($range, $range);
+
+    if ($colunaAtual > $num_cols) {
+        $opcoes[$colunaAtual] = 'Sem coluna';
     }
+
+    ksort($opcoes);
+
+    return $opcoes;
+}
 
     public function ordemArray($coluna = null)
     {

--- a/database/factories/GrupoFactory.php
+++ b/database/factories/GrupoFactory.php
@@ -23,9 +23,13 @@ class GrupoFactory extends Factory
     {
         $descricao = (rand(1, 10) > 8) ? $this->faker->text : '';
         $exibir = (rand(1, 10) > 9) ? false : true;
+
+        $num_cols = config('portal-sistemas.num_cols', 3);
+        $coluna = (rand(1, 10) > 8) ? ($num_cols + 1) : rand(1, $num_cols);
+
         return [
             'nome' => $this->faker->word,
-            'coluna' => rand(1, 4),
+            'coluna' => $coluna,
             'descricao' => $descricao,
             'exibir' => $exibir,
         ];

--- a/resources/views/livewire/grupo-form.blade.php
+++ b/resources/views/livewire/grupo-form.blade.php
@@ -1,16 +1,30 @@
 <div>
-  <form wire:submit.prevent="salvarGrupo">
-    <div class="d-flex">
-      <x-wire-input-text model="grupo.nome" prepend="Nome" class="mr-auto" />
-      <x-wire-select prepend="COL" :options="$colunaArray" model="grupo.coluna" />
-      <x-wire-select prepend="LIN" :options="$ordemArray" model="grupo.linha" />
-      <x-wire-switch label="Exibir" model="grupo.exibir" />
-    </div>
-    <x-wire-textarea label="Descrição" model="grupo.descricao" />
+    <form wire:submit.prevent="salvarGrupo">
+        <div class="d-flex align-items-center mb-3">
 
-    <div class="d-flex flex-row">
-      <button type="button" class="btn btn-sm btn-secondary" data-dismiss="modal">Cancelar</button>
-      <button type="submit" class="btn btn-sm btn-primary ml-2">Salvar</button>
-    </div>
-  </form>
+            <div class="flex-grow-1 mr-3">
+                <x-wire-input-text model="grupo.nome" prepend="Nome" />
+            </div>
+
+            <div class="mr-3 flex-shrink-0" wire:key="select-coluna-{{ $grupo->id ?? 'novo' }}">
+                <x-wire-select prepend="COL" :options="$colunaArray" model="grupo.coluna" />
+            </div>
+
+            <div class="mr-3 flex-shrink-0" wire:key="select-linha-{{ $grupo->id ?? 'novo' }}">
+                <x-wire-select prepend="LIN" :options="$ordemArray" model="grupo.linha" />
+            </div>
+
+            <div class="flex-shrink-0">
+                <x-wire-switch label="Exibir" model="grupo.exibir" />
+            </div>
+
+        </div>
+
+        <x-wire-textarea label="Descrição" model="grupo.descricao" />
+
+        <div class="d-flex flex-row mt-3">
+            <button type="button" class="btn btn-sm btn-secondary" data-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-sm btn-primary ml-2">Salvar</button>
+        </div>
+    </form>
 </div>

--- a/resources/views/livewire/partials/grupo-card.blade.php
+++ b/resources/views/livewire/partials/grupo-card.blade.php
@@ -1,29 +1,29 @@
 <div class="card mb-3" wire:key="grupo-{{ $grupo->id }}">
-  <div class="card-header py-2">
-    <span class="h4 py-0">
-      @if (!$grupo->exibir)
-        <span class="badge text-warning"><i class="fas fa-eye-slash"></i></span>
-      @endif
-      {{ $grupo->nome }}
-    </span>
-    @includeWhen(Gate::allows('manager'), 'livewire.partials.badge-grupo-sem-coluna')
-    @includeWhen($gerenciar, 'livewire.partials.grupo-menu')
-    <div class="text-secondary">{{ $grupo->descricao }}</div>
-  </div>
-
-  <div class="card-body">
-    <ul wire:sortable="updateItensOrder" class="list-group">
-      @foreach ($grupo->itens as $item)
-        <li wire:sortable.item="{{ $item->id }}" wire:key="item-{{ $item->id }}"
-          class="list-group-item border-0 py-0 px-0">
-          <div class="form-inline">
-            @if ($gerenciar)
-              {{-- <span wire:sortable.handle class="mr-1"><i class="fas fa-grip-lines text-secondary"></i></span> --}}
+    <div class="card-header py-2">
+        <span class="h4 py-0">
+            @if (!$grupo->exibir)
+                <span class="badge text-warning"><i class="fas fa-eye-slash"></i></span>
             @endif
-            @includeWhen($item->exibir || Gate::check('manager'), 'livewire.partials.item')
-          </div>
-        </li>
-      @endforeach
-    </ul>
-  </div>
+            {{ $grupo->nome }}
+        </span>
+        @includeWhen($isManager, 'livewire.partials.badge-grupo-sem-coluna')
+        @includeWhen($gerenciar, 'livewire.partials.grupo-menu')
+        <div class="text-secondary">{{ $grupo->descricao }}</div>
+    </div>
+
+    <div class="card-body">
+        <ul wire:sortable="updateItensOrder" class="list-group">
+            @foreach ($grupo->itens as $item)
+                <li wire:sortable.item="{{ $item->id }}" wire:key="item-{{ $item->id }}"
+                    class="list-group-item border-0 py-0 px-0">
+                    <div class="form-inline">
+                        @if ($gerenciar)
+                            {{-- <span wire:sortable.handle class="mr-1"><i class="fas fa-grip-lines text-secondary"></i></span> --}}
+                        @endif
+                        @includeWhen($item->exibir || $isManager, 'livewire.partials.item')
+                    </div>
+                </li>
+            @endforeach
+        </ul>
+    </div>
 </div>

--- a/resources/views/livewire/partials/grupo-card.blade.php
+++ b/resources/views/livewire/partials/grupo-card.blade.php
@@ -1,4 +1,4 @@
-<div class="card mb-3">
+<div class="card mb-3" wire:key="grupo-{{ $grupo->id }}">
   <div class="card-header py-2">
     <span class="h4 py-0">
       @if (!$grupo->exibir)

--- a/resources/views/livewire/partials/item.blade.php
+++ b/resources/views/livewire/partials/item.blade.php
@@ -1,4 +1,4 @@
-<div class="to-hover hover-bg item">
+<div class="to-hover hover-bg item" wire:key="item-{{ $item->id }}">
   @if (!$item->exibir)
     <span class="badge text-warning"><i class="fas fa-eye-slash"></i></span>
   @endif

--- a/resources/views/livewire/show-grupos.blade.php
+++ b/resources/views/livewire/show-grupos.blade.php
@@ -6,7 +6,7 @@
 
         {{-- Mostra os grupos de uma mesma coluna --}}
         @foreach ($grupos->where('coluna', $col)->sortBy('linha') as $grupo)
-          @if ($grupo->exibir || Gate::check('manager'))
+          @if ($grupo->exibir || $isManager)
             @include('livewire.partials.grupo-card')
           @endif
         @endforeach
@@ -29,7 +29,7 @@
   </div>
 
   {{-- Itens sem grupo --}}
-  @includeWhen(Gate::allows('manager') && $itensSemGrupo->isNotEmpty(), 'livewire.partials.itens-sem-grupo')
+  @includeWhen($isManager && $itensSemGrupo->isNotEmpty(), 'livewire.partials.itens-sem-grupo')
 
   <!-- Modal de grupo -->
   <div class="modal" tabindex="-1" id="modalGrupo">


### PR DESCRIPTION
### 1. Correção do desaparecimento de elementos na interface

**Commit:** `fix: Corrige desaparecimento dos botões de edição após salvar grupo ou item` (`d4fd450`)

* **Problema:** Após salvar um grupo ou item, os botões de edição e elementos condicionais da tela desapareciam.
* **Causa:** O Livewire utiliza o Morphdom para comparar o HTML antigo com o novo (DOM Diffing) durante atualizações. Como os `@foreach` não possuíam uma id, o Livewire perdia a referência dos elementos, causando a remoção de componentes. Além disso, novos itens criados não eram renderizados corretamente.
* **Solução:** Adição da diretiva obrigatória `wire:key` nas divs imediatamente dentro dos `@foreach`.

### 2. Estabilização e proteção da exibição de itens ocultos

**Commit:** `fix: preserva exibição de itens ocultos armazenando permissão com #[Locked]` (`9fd71d4`)

* **Problema:** A checagem dinâmica de permissão na view gerava instabilidade na exibição de elementos ocultos durante as requisições AJAX.
* **Solução:** A verificação foi movida para o `mount()` e armazenada na propriedade `$isManager`. Para evitar manipulações forçadas no frontend via console do navegador, a variável foi protegida com o atributo `#[Locked]` (criptografia nativa do Livewire).

### 3. Correção de vulnerabilidade crítica na Autorização

**Commit:** `fix(security): substitui Gate::allows por Gate::authorize nos formulários` (`cec1d8c`)

* **Problema:** O uso de `Gate::allows()` solto nos métodos de ação era ineficaz. Como ele apenas retorna um booleano e não interrompe o fluxo, abria brechas para execução de ações maliciosas via manipulação do frontend.
* **Solução:** Esta solução foi sobreposta pela refatoração do commit 4.

### 4. Refatoração do ciclo de vida e resolução de falsos bloqueios

**Commit:** `fix(auth): impede perda de permissão via AJAX e refatora ciclo de vida dos formulários` (`8f30dac`)

* **Problema:** Falsos-positivos de Erro 403 bloqueavam usuários com permissões válidas ao tentar salvar ou editar dados.
* **Causa:** Conflito entre a injeção de permissões via `.env` (do pacote `senhaunica-socialite`) e as requisições AJAX do Livewire. Isso era agravado pelo uso incorreto de `$this->mount()` nas funções de ação, que forçava a reavaliação da permissão fora do ciclo inicial e sobrescrevia a variável `$isManager` para `false`. *(Nota: O problema de injeção afeta apenas acessos validados via `.env`, não impactando usuários persistidos no banco de dados).*
* **Solução:** A lógica de reset foi isolada no novo método `limparFormulario()`. O `mount()` agora roda apenas na inicialização, como indica a documentação do Livewire.

### 5. Correção na edição de posição de grupos sem coluna

**Commit:** `fix: corrige edição de posição e falhas visuais em grupos sem coluna`

* **Problema:** A edição de grupos "sem coluna" exibia "1" por padrão no dropdown, gerando erros de ordenação ao salvar. Além disso, o layout do formulário quebrava e cortava os textos dos selects.
* **Causa:** A coluna atual do grupo não era repassada para as opções do `<select>`, causando dessincronia no Livewire (Morphdom). Havia também falhas de Flexbox no CSS e o backend aceitava valores inválidos.
* **Solução:** * O método `colunaArray()` passou a incluir dinamicamente a opção "Sem coluna".
* Adicionado `wire:key` aos selects para forçar a renderização correta no primeiro clique.
* Aplicado `flex-shrink-0` e `flex-grow-1` para corrigir o layout.
* Adicionada validação estrita (`in:`) no backend para impedir manipulação de colunas via console.
